### PR TITLE
Fixing bug of 1st character cropping

### DIFF
--- a/backend/services/admin/viewsets/teamtasks.py
+++ b/backend/services/admin/viewsets/teamtasks.py
@@ -11,8 +11,8 @@ class TeamTaskApi(ApiSet):
     @staticmethod
     def list():
         try:
-            team_id = int(request.args['team_id'][0])
-            task_id = int(request.args['task_id'][0])
+            team_id = int(request.args['team_id'])
+            task_id = int(request.args['task_id'])
         except (KeyError, ValueError):
             return make_err_response(
                 'Provide team_id and task_id as get params',


### PR DESCRIPTION
When we're tryana to get 
/api/admin/teamtasks/?team_id=12&task_id=5
you've cropped 12 by zero char (1)
so, API works unexpectedly